### PR TITLE
fix open local file with cygstart from vim-quickrun

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -353,7 +353,12 @@ function! s:convert_uri(uri) "{{{
         let save_shellslash = &shellslash
         let &l:shellslash = 1
         try
-            return 'file:///' . fnamemodify(a:uri, ':p')
+            let uri = fnamemodify(a:uri, ':p')
+            if g:__openbrowser_platform.cygwin
+                return uri
+            else
+                return 'file:///' . uri
+            endif
         finally
             let &l:shellslash = save_shellslash
         endtry


### PR DESCRIPTION
**まず, 結論ですが, file:/// が足されないようにcygwinで場合分けすることにしました.**

[cygstart](http://cygwin.com/cgi-bin/cvsweb.cgi/cygutils/src/cygstart/cygstart.c?cvsroot=cygwin-apps) とverboseオプションを見るに, URIスキームの時だけ変換しないようです. が, どちらにせよ, openbrowser側で対応が要るようでした.

上手くいかない例:

```
$ cygstart --verbose -o file:////tmp/vykkCuC/4.html
ShellExecute(NULL, "open", "file:////tmp/vykkCuC/4.html", "(null)", "(null)", 1)
(しばらく停止)
Unable to start 'file:////tmp/vykkCuC/4.html': The specified file was not found.
(起動せず)
```

うまくいく例:

```
$ cygstart --verbose /tmp/vykkCuC/4.html
ShellExecute(NULL, "(null)", "C:\cygwin\tmp\vykkCuC\4.html", "(null)", "(null)", 1)
(ブラウザ起動)
```

cygpathで変換してうまくいく例:

```
$ cygstart --verbose "file:///$(cygpath --mixed /tmp/vykkCuC/4.html)"
ShellExecute(NULL, "(null)", "file:///C:/cygwin/tmp/vykkCuC/4.html", "(null)", "(null)", 1)
```

で, このあたりの処理を s:get_default_open_rules に追加すればよいかと考えたのですが,
get_default_open_rulesが処理される前に, s:convert_uri で file:/// が追加されてしまってました orz

ので, 変更の少なくしたいのと, cygpathを呼ぶ不都合の可能性もあわせて, cygpathにそのまま渡す形にしました.(file:/// がたされないようにcygwinで場合分け)
