### PR TITLE
fixed convert to fullpath

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -359,7 +359,7 @@ function! s:convert_to_fullpath(path) "{{{
     let save_shellslash = &shellslash
     let &l:shellslash = 1
     try
-        let path = fnamemodify(a:path, ':p')
+        return fnamemodify(a:path, ':p')
     finally
         let &l:shellslash = save_shellslash
     endtry


### PR DESCRIPTION
変換したパス名を返していないので、常に 0 がファイル名になってしまっています。
