### PR TITLE
Speedup startup on Cygwin by avoiding costly system() call.

### DIFF
--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -16,7 +16,7 @@ set cpo&vim
 let s:is_unix = has('unix')
 let s:is_mswin = has('win16') || has('win32') || has('win64')
 let s:is_cygwin = has('win32unix')
-let s:is_macunix = !s:is_mswin && (has('mac') || has('macunix') || has('gui_macvim') || system('uname') =~? '^darwin')
+let s:is_macunix = !s:is_mswin && !s:is_cygwin && (has('mac') || has('macunix') || has('gui_macvim') || system('uname') =~? '^darwin')
 lockvar s:is_unix
 lockvar s:is_mswin
 lockvar s:is_cygwin


### PR DESCRIPTION
By chance I discovered during profiling the Vim startup that open-browser was in the top 3 of Vim startup time. Analysis showed that this was caused by an unnecessary `system('uname')` call in the Mac detection; forking a new process is especially slow on Cygwin, due to the architecture mismatch with the underlying Windows subsystem.
