### PR TITLE
Allow to disable the default search engines.

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -109,31 +109,6 @@ if !exists('g:openbrowser_default_search')
     let g:openbrowser_default_search = 'google'
 endif
 
-let g:openbrowser_search_engines = extend(
-\   get(g:, 'openbrowser_search_engines', {}),
-\   {
-\       'alc': 'http://eow.alc.co.jp/{query}/UTF-8/',
-\       'askubuntu': 'http://askubuntu.com/search?q={query}',
-\       'baidu': 'http://www.baidu.com/s?wd={query}&rsv_bp=0&rsv_spt=3&inputT=2478',
-\       'blekko': 'http://blekko.com/ws/+{query}',
-\       'cpan': 'http://search.cpan.org/search?query={query}',
-\       'duckduckgo': 'http://duckduckgo.com/?q={query}',
-\       'github': 'http://github.com/search?q={query}',
-\       'google': 'http://google.com/search?q={query}',
-\       'google-code': 'http://code.google.com/intl/en/query/#q={query}',
-\       'php': 'http://php.net/{query}',
-\       'python': 'http://docs.python.org/dev/search.html?q={query}&check_keywords=yes&area=default',
-\       'twitter-search': 'http://twitter.com/search/{query}',
-\       'twitter-user': 'http://twitter.com/{query}',
-\       'verycd': 'http://www.verycd.com/search/entries/{query}',
-\       'vim': 'http://www.google.com/cse?cx=partner-pub-3005259998294962%3Abvyni59kjr1&ie=ISO-8859-1&q={query}&sa=Search&siteurl=www.vim.org%2F#gsc.tab=0&gsc.q={query}&gsc.page=1',
-\       'wikipedia': 'http://en.wikipedia.org/wiki/{query}',
-\       'wikipedia-ja': 'http://ja.wikipedia.org/wiki/{query}',
-\       'yahoo': 'http://search.yahoo.com/search?p={query}',
-\   },
-\   'keep'
-\)
-
 if !exists('g:openbrowser_open_filepath_in_vim')
     let g:openbrowser_open_filepath_in_vim = 1
 endif

--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -37,6 +37,35 @@ let g:__openbrowser_platform = {
 \   'macunix': s:is_macunix,
 \}
 
+" Global Variables {{{
+let g:openbrowser_search_engines = extend(
+\   get(g:, 'openbrowser_search_engines', {}),
+\   {
+\       'alc': 'http://eow.alc.co.jp/{query}/UTF-8/',
+\       'askubuntu': 'http://askubuntu.com/search?q={query}',
+\       'baidu': 'http://www.baidu.com/s?wd={query}&rsv_bp=0&rsv_spt=3&inputT=2478',
+\       'blekko': 'http://blekko.com/ws/+{query}',
+\       'cpan': 'http://search.cpan.org/search?query={query}',
+\       'duckduckgo': 'http://duckduckgo.com/?q={query}',
+\       'github': 'http://github.com/search?q={query}',
+\       'google': 'http://google.com/search?q={query}',
+\       'google-code': 'http://code.google.com/intl/en/query/#q={query}',
+\       'php': 'http://php.net/{query}',
+\       'python': 'http://docs.python.org/dev/search.html?q={query}&check_keywords=yes&area=default',
+\       'twitter-search': 'http://twitter.com/search/{query}',
+\       'twitter-user': 'http://twitter.com/{query}',
+\       'verycd': 'http://www.verycd.com/search/entries/{query}',
+\       'vim': 'http://www.google.com/cse?cx=partner-pub-3005259998294962%3Abvyni59kjr1&ie=ISO-8859-1&q={query}&sa=Search&siteurl=www.vim.org%2F#gsc.tab=0&gsc.q={query}&gsc.page=1',
+\       'wikipedia': 'http://en.wikipedia.org/wiki/{query}',
+\       'wikipedia-ja': 'http://ja.wikipedia.org/wiki/{query}',
+\       'yahoo': 'http://search.yahoo.com/search?p={query}',
+\   },
+\   'keep'
+\)
+
+" }}}
+
+
 " Interfaces {{{
 
 " For backward compatibility,


### PR DESCRIPTION
With the current definition of `g:openbrowser_search_engines` in the autoload script, one has to `:runtime` that in order to disable all default search engines, which is against the autoload idea of lazy loading. By moving the default search engine definitions to the plugin script, it becomes possible to easily turn them off without runtime penalty:

```
" I do not want any of the default search engines.
runtime! plugin/openbrowser.vim
let g:openbrowser_search_engines = {}
```

Apart from that, there's no change in the behavior of the config variable: Earlier definitions from a .vimrc are still added with preference.
