### PR TITLE
コマンドに渡す文字列が正しく生成されない

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -282,7 +282,7 @@ function! s:open_browser(uri) "{{{
 
         let cmdline = s:expand_keywords(
         \   cmd.args,
-        \   {'browser': cmd.args, 'uri': uri}
+        \   {'browser': cmd.name, 'uri': uri}
         \)
         call s:system(cmdline)
 


### PR DESCRIPTION
revertされた 3fb3fa9 で browser の値が cmd.args となっており、コマンド文字列として正しくない値が生成されていて開くことができませんでしたので、cmd.name に変更しました。

OS Xでの動作を確認しています。(open)
