### PR TITLE
added g:openbrowser_short_message

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -398,7 +398,7 @@ function! s:open_browser(uri) "{{{
         " so can't check its return value.
         redraw
         if g:openbrowser_short_message
-          echo "opening ... done!"
+          echo "opening ... done! (" . browser . ")"
         else
           echo "opening '" . uri . "' ... done! (" . browser . ")"
         endif


### PR DESCRIPTION
url が長い場合にウインドウのサイズが足らないと

```
opening  'http://ながーーーーーーーーーーーーーーーーーーーーーいurl' ... done! (open)
続けるにはENTERを押すかコマンドを入力してください
```

と表示されてしまい、キー操作を強制されてしまうのをなんとかできないかなと思い、
1 案ですがリクエストします。

```
g:openbrowser_short_message = 1
```

とすると

```
opening  ... done! (open)
```

と表示されるようになるので、ENTER を強制されることがなくなります。

引数指定できた方が良さそうではありますが、力及ばず・・・です。
