### PR TITLE
added g:openbrowser_short_message

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -277,7 +277,11 @@ function! s:open_browser(uri) "{{{
     let uri = a:uri
 
     redraw
-    echo "opening '" . uri . "' ..."
+    if g:openbrowser_short_message
+      echo "opening ..."
+    else
+      echo "opening '" . uri . "' ..."
+    endif
 
     for cmd in s:get_var('openbrowser_browser_commands')
         if !executable(cmd.name)
@@ -295,7 +299,11 @@ function! s:open_browser(uri) "{{{
         " so can't check its return value.
 
         redraw
-        echo "opening '" . uri . "' ... done! (" . cmd.name . ")"
+        if g:openbrowser_short_message
+          echo "opening ... done! (" . cmd.name . ")"
+        else
+          echo "opening '" . uri . "' ... done! (" . cmd.name . ")"
+        endif
         return
     endfor
 

--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -169,6 +169,9 @@ endif
 if !exists('g:openbrowser_open_vim_command')
     let g:openbrowser_open_vim_command = 'vsplit'
 endif
+if !exists('g:openbrowser_short_message')
+    let g:openbrowser_short_message = 0
+endif
 " }}}
 
 


### PR DESCRIPTION
※ head を取り直して pull request しなおしました。

url が長い場合にウインドウのサイズが足らないと

```
opening  'http://ながーーーーーーーーーーーーーーーーーーーーーいurl' ... done! (open)
続けるにはENTERを押すかコマンドを入力してください
```

と表示されてしまい、キー操作を強制されてしまうのをなんとかできないかなと思い、
1 案ですがリクエストします。

```
g:openbrowser_short_message = 1
```

とすると

```
opening  ... done! (open)
```

と表示されるようになるので、ENTER を強制されることがなくなります。

引数指定できた方が良さそうではありますが、力及ばず・・・です。
