### PR TITLE
Fixed g:openbrowser_browser_commands's default value

### DIFF
--- a/doc/openbrowser.txt
+++ b/doc/openbrowser.txt
@@ -110,10 +110,32 @@ VARIABLES					*openbrowser-variables* {{{
 g:openbrowser_browser_commands		*g:openbrowser_browser_commands*
 								(default: Platform dependent)
 	Default value is platform dependant.
-	Cygwin: ["cygstart"]
-	Mac OS X: ["open"]
-	MS Windows: ["cmd.exe"]
-	Unix like environment: ['xdg-open', 'x-www-browser', 'firefox', 'w3m']
+	Cygwin:
+		[
+		\ {"name": "cygstart",
+		\  "args": ["{browser}", "{uri}"]}
+		\]
+	Mac OS X:
+		[
+		\ {"name": "open",
+		\  "args": ["{browser}", "{uri}"]}
+		\]
+	MS Windows:
+		[
+		\ {"name": "rundll32",
+		\  "args": "rundll32 url.dll,FileProtocolHandler {uri}"}
+		\]
+	Unix like environment:
+		[
+		\ {"name": "xdg-open",
+		\  "args": ["{browser}", "{uri}"]},
+		\ {"name": "x-www-browser",
+		\  "args": ["{browser}", "{uri}"]},
+		\ {"name": "firefox",
+		\  "args": ["{browser}", "{uri}"]},
+		\ {"name": "w3m",
+		\  "args": ["{browser}", "{uri}"]},
+		\]
 
 g:openbrowser_open_commands			*g:openbrowser_open_commands*
 g:openbrowser_open_rules			*g:openbrowser_open_rules*


### PR DESCRIPTION
`g:openbrowser_open_commands` が廃止され `g:openbrowser_browser_commands` が導入されてから，変数の値もコマンド文字列のリストから`name` と `args` をキーに持つ辞書のリストに変更されたようですが，ドキュメントのほうが古いままだったので修正しました．
