### PR TITLE
Fixed conversion from old variables

### DIFF
--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -102,10 +102,10 @@ function! s:convert_commands_and_rules()
     let open_rules    = g:openbrowser_open_rules
     let browser_commands = []
     for cmd in open_commands
-        call add(browser_commands, [
-        \   {'name': cmd,
-        \    'args': open_rules[cmd]}
-        \])
+        call add(browser_commands,{
+        \ 'name': cmd,
+        \ 'args': open_rules[cmd]
+        \})
     endfor
     return browser_commands
 endfunction


### PR DESCRIPTION
deprecated な `g:openbrowser_open_commands` と `g:openbrowser_open_rules` から `g:openbrowser_browser_commands` に変換する処理で，`add()` にリストを渡してしまっているため，`g:openbrowser_browser_commands` が2重のリストになってしまっていたので修正しました．
