### PR TITLE
use system and s/redraw!/redraw/ (close #36)

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -276,7 +276,7 @@ function! s:open_browser(uri) "{{{
             \   v:val,
             \   {"browser": cmd.name, "uri": uri}
             \)')
-            let command = join(cmdline, ' ')
+            let command = join(map(cmdline, "escape(v:val, '''')"), ' ')
         else
             let cmdline = s:expand_keywords(
             \   cmd.args,


### PR DESCRIPTION
system()を使うことで, redraw!をredrawにしました.
これにより, バッファー全体がちらつくのを防ぎます.
issueでは command . '&' すると書きましたが, こうするとコマンドが終了する前に ... done となってしまうので, '&' をつけるのは辞めました.
