### PR TITLE
Fixed ignoring hash in URL

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -279,7 +279,7 @@ function! s:open_browser(uri) "{{{
             \   v:val,
             \   {"browser": cmd.name, "uri": uri}
             \)')
-            let command = join(map(cmdline, "escape(v:val, '''')"), ' ')
+            let command = join(map(cmdline, "escape(v:val, '''#')"), ' ')
         else
             let cmdline = s:expand_keywords(
             \   cmd.args,


### PR DESCRIPTION
hi．

`OpenBrowser https://github.com/rhysd/dotfiles/blob/master/vimrc#L1` を実行すると，実際には https://github.com/rhysd/dotfiles/blob/master/vimrc が開かれてしまうという問題を見つけました．どうやら，vimproc のパーサが # 以降をコメントとして扱ってしまうのが問題のようです．

なので，URL 内の `#` を `\#` のようにエスケープするようにしました．もし vimproc が無い環境だったとしても，エスケープされた `\#` はただの `#` になるはずなので問題無いと思います．自分の手元ではいくつかの URL で試してみて，問題なく動いているのを一応確認しています（Mac）．

openbrowser-github.vim で範囲指定して開いた場合に困るので，問題なさそうなら取り込んでいただけるとありがたいです．よろしくお願いします．
