### PR TITLE
new variable: g:openbrowser_message

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -280,7 +280,7 @@ function! s:open_browser(uri) "{{{
     let uri = a:uri
 
     redraw
-    if g:openbrowser_message
+    if g:openbrowser_show_message
         if g:openbrowser_short_message
           echo "opening ..."
         else
@@ -318,7 +318,7 @@ function! s:open_browser(uri) "{{{
         " so can't check its return value.
 
         redraw
-        if g:openbrowser_message
+        if g:openbrowser_show_message
             if g:openbrowser_short_message
               echo "opening ... done! (" . cmd.name . ")"
             else

--- a/doc/openbrowser.txt
+++ b/doc/openbrowser.txt
@@ -225,8 +225,8 @@ g:openbrowser_open_vim_command
 	This value is used for opening looks-like-a-path string.
 	See |g:openbrowser_open_filepath_in_vim| for the details.
 
-					*g:openbrowser_message*
-g:openbrowser_message
+					*g:openbrowser_show_message*
+g:openbrowser_show_message
 								(default: 1)
 	If this value is true, it shows 'opening ...' message when opening a URL.
 

--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -167,8 +167,8 @@ endif
 if !exists('g:openbrowser_open_vim_command')
     let g:openbrowser_open_vim_command = 'vsplit'
 endif
-if !exists('g:openbrowser_message')
-    let g:openbrowser_message = 1
+if !exists('g:openbrowser_show_message')
+    let g:openbrowser_show_message = 1
 endif
 if !exists('g:openbrowser_short_message')
     let g:openbrowser_short_message = 0


### PR DESCRIPTION
`g:openbrowser_message`を0にすると、opening...というメッセージを消すことが出来ます。
ユーザーが何も設定しなければ、これまでの挙動と同じです。
