### PR TITLE
Improve URL regexp (#58, #42)

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -401,7 +401,9 @@ function! openbrowser#get_url_on_cursor() "{{{
     let PROTO = '\(https\?\|ftp\)'
     let HOST = '[a-zA-Z0-9][a-zA-Z0-9_-]*\(\.[a-zA-Z0-9][a-zA-Z0-9_-]*\)*'
     let PORT = '\(:\d\+\)\?'
-    let PATH_FRAGMENT = '\(/[a-zA-Z0-9_/+%#?&=;@$!*~-]*\)\?'
+    let CHARS = '['',.a-zA-Z0-9_/+%#?&=;@$!*~-]'
+    let LAST_CHAR = '[a-zA-Z0-9_/+%#?&=;@$!*~-]'
+    let PATH_FRAGMENT = '\(/' . CHARS . '*' . LAST_CHAR . '\)\?'
     let re_url = PROTO . '://' . HOST . PORT . PATH_FRAGMENT
     let matchstart = 0
     while 1


### PR DESCRIPTION
via #58 @blueyed 

**_I don't intend to merge this branch.**_

**The last character** must not contain:
- '(single-quote)
- ,(comma)
- .(period)

Because those characters are rarely included in URL.
Mostly, open-browser.vim **wrongly** detects it as a part of URL.
