### PR TITLE
Remove undefined command PP!

### DIFF
--- a/autoload/vital/_openbrowser/Process.vim
+++ b/autoload/vital/_openbrowser/Process.vim
@@ -144,7 +144,6 @@ function! s:system(str, ...)
     let command = s:iconv(command, &encoding, 'char')
   endif
   let args = [command] + args
-  PP! args
 
   let funcname = use_vimproc ? 'vimproc#system' : 'system'
   let output = call(funcname, args)


### PR DESCRIPTION
いつも便利に使わせていただいています。

vimを使い始めて2週間ぐらいなので、自分の環境依存の現象の勘違いだったらすいません。
PP!コマンドがありませんというメッセージでOpenBrowserの途中で動かなくなっており、
取り除いたところ動くようになったので、おそらく不要な行か、別のことを記載するはずだった行なのではないか
と思うのですが、いかがでしょうか。もし違っていたらすいません。

動作環境:  VIM 7.4.475 (Kaoriya ver) (64bit) /Win7(64bit)
