### PR TITLE
:OpenBrowser should open file with browser by default

### DIFF
--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -168,7 +168,7 @@ let g:openbrowser_search_engines = extend(
 \)
 
 if !exists('g:openbrowser_open_filepath_in_vim')
-    let g:openbrowser_open_filepath_in_vim = 1
+    let g:openbrowser_open_filepath_in_vim = 0
 endif
 if !exists('g:openbrowser_open_vim_command')
     let g:openbrowser_open_vim_command = 'vsplit'


### PR DESCRIPTION
ローカルの html ファイルをブラウザで開こうとした時に Vim の中で開くようになっていたので ？ と思ってちょっと調べてみたのですが，デフォルトで `:vsplit` で開くのがデフォルトになっているようでした．

```vim
if !exists('g:openbrowser_open_filepath_in_vim')
    let g:openbrowser_open_filepath_in_vim = 1
endif
```

これってどういう理由なのでしょうか？ Vim 内で開きたければ `:vsplit` を使いますし，ブラウザで開きたいから `:OpenBrowser` を使うのだと思うのですが…
この辺りの理由教えてもらえるとありがたいです．理由はローカルの html なドキュメントファイルを開くプラグインが open-browser.vim に依存していて，こちらで対応を入れるべきか open-browser.vim 側に修正をお願いする（＝このプルリクを取り込んでもらう）か判断できなかったからです．

