### PR TITLE
Allow the url without dots

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -385,7 +385,6 @@ endfunction "}}}
 function! s:seems_uri(uriobj) "{{{
     return !empty(a:uriobj)
     \   && a:uriobj.scheme() !=# ''
-    \   && a:uriobj.host() =~# '\.'
 endfunction "}}}
 
 function! s:detect_query_type(query, ...) "{{{


### PR DESCRIPTION
ドットがあるかどうかで判定すると、 http://localhost/foo/bar みたいなのが開けないです…

e.g.
  http://localhost/foo/bar