### PR TITLE
Fix failed CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ script:
   - vim --cmd "try | helptags doc/ | catch | cquit | endtry" --cmd quit
   - sh /tmp/vim-vimlint/bin/vimlint.sh -l /tmp/vim-vimlint -p /tmp/vim-vimlparser -e EVL103=1 -e EVL102.l:_=1 autoload plugin
   - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --runtimepath /tmp/vmock --reporter dot
+
+git:
+  depth: 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-clone_depth: 1
+clone_depth: 10
 environment:
   matrix:
    - VIM_URL: http://vim-jp.org/redirects/koron/vim-kaoriya/latest/win64/


### PR DESCRIPTION
via #85 

> Build failures were caused by the same reason as the following issues:
> - https://github.com/vim-jp/vital.vim/pull/427
> - https://github.com/vim-jp/vital.vim/pull/428
