### PR TITLE
Fix neovim working

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -6,7 +6,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 " }}}
 
-let s:V = vital#of('openbrowser')
+let s:V = vital#openbrowser#of()
 let s:Prelude = s:V.import('Prelude')
 let s:String = s:V.import('Data.String')
 let s:Process = s:V.import('Process')

--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -6,7 +6,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 " }}}
 
-let s:V = vital#openbrowser#of()
+let s:V = vital#of('openbrowser')
 let s:Prelude = s:V.import('Prelude')
 let s:String = s:V.import('Data.String')
 let s:Process = s:V.import('Process')

--- a/autoload/vital/_openbrowser/Process.vim
+++ b/autoload/vital/_openbrowser/Process.vim
@@ -149,7 +149,8 @@ function! s:system(str, ...) abort
     let command = s:iconv(command, &encoding, 'char')
   endif
   let args = [command] + args
-  if background && (use_vimproc || !s:is_windows)
+  "NOTE: neovim cannot use '&' in system() at 2017-01-13, see :h system()
+  if background && (use_vimproc || !s:is_windows) && !has('nvim')
     let args[0] = args[0] . ' &'
   endif
 


### PR DESCRIPTION
Now, open-browser didn't work on neovim.  
Its reason is the bug of the vital module (Process.vim).

I fixed it :smile:

(I pull requested its fixing to vim-jp/vital.vim)
