### PR TITLE
Add g:openbrowser_message_verbosity variable

### DIFF
--- a/autoload/openbrowser.vim
+++ b/autoload/openbrowser.vim
@@ -448,9 +448,11 @@ endfunction "}}}
 function! openbrowser#__open_browser__(uristr) "{{{
   let uri = a:uristr
 
+  " Clear previous message
+  redraw!
+
   let format_message = s:get_var('openbrowser_format_message')
   if format_message.msg !=# ''
-    redraw
     let msg = s:expand_format_message(format_message,
     \   {
     \      'uri' : uri,

--- a/doc/openbrowser.txt
+++ b/doc/openbrowser.txt
@@ -321,6 +321,17 @@ g:openbrowser_format_message
 		2.2. After 2.1, if URI is longer than command-line, then
 			2.2.1. Truncate whole string.
 
+					*g:openbrowser_message_verbosity*
+g:openbrowser_message_verbosity
+								(default: 2)
+	value meaning ~
+	0     no messages / no error messages
+	1     no messages / show error messages
+	2     show messages / show error messages
+
+	NOTE: Even if this value is 2, no messages are echoed when
+	|g:openbrowser_format_message|.msg is empty value.
+
 					*g:openbrowser_use_vimproc*
 g:openbrowser_use_vimproc
 								(default: 1)

--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -195,6 +195,8 @@ else
 endif
 unlet s:FORMAT_MESSAGE_DEFAULT
 
+let g:openbrowser_message_verbosity = get(g:, 'openbrowser_message_verbosity', 2)
+
 let g:openbrowser_use_vimproc = get(g:, 'openbrowser_use_vimproc', 1)
 let g:openbrowser_force_foreground_after_open = get(g:, 'openbrowser_force_foreground_after_open', 0)
 " }}}


### PR DESCRIPTION
Fix #94 

This PR adds `g:openbrowser_message_verbosity` variable.
`let g:openbrowser_message_verbosity = 0` to silence all messages / error messages to user (except internal errors).