### PR TITLE
Avoid using background with 'open' on os x.

### DIFF
--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -61,8 +61,7 @@ elseif g:__openbrowser_platform.macunix
   function! s:get_default_browser_commands()
     return [
     \   {'name': 'open',
-    \    'args': ['{browser}', '{uri}'],
-    \    'background': 1}
+    \    'args': ['{browser}', '{uri}']}
     \]
   endfunction
 elseif g:__openbrowser_platform.mswin


### PR DESCRIPTION
Getting these errors in neovim:

```
open-browser failed to open URI...
v:exception = vital: Process: neovim's system() doesn't support background(&) process (cmdline:['open', 'http://www.google.com'])
v:throwpoint = function openbrowser#_keymapping_open[6]..openbrowser#open[60]..openbrowser#__open_browser__[43]..openbrowser#__system__[1]..<SNR>187_system, line 53


```