### PR TITLE
[WSL] Fix rundll32.exe path

### DIFF
--- a/plugin/openbrowser.vim
+++ b/plugin/openbrowser.vim
@@ -81,12 +81,19 @@ elseif g:__openbrowser_platform.unix
   function! s:get_default_browser_commands()
     if filereadable('/proc/version_signature') &&
     \ get(readfile('/proc/version_signature', 'b', 1), 0, '') =~# '^Microsoft'
-      " Windows Subsystem for Linux
-      return [
-      \   {'name': 'rundll32',
-      \    'cmd': '/mnt/c/Windows/System32/rundll32.exe',
-      \    'args': '/mnt/c/Windows/System32/rundll32.exe url.dll,FileProtocolHandler {use_vimproc ? uri : uri_noesc}'}
+      " Windows Subsystem for Linux (recent version's directory name is 'WINDOWS')
+      for rundll32 in [
+      \ '/mnt/c/WINDOWS/System32/rundll32.exe',
+      \ '/mnt/c/Windows/System32/rundll32.exe',
       \]
+        if executable(rundll32)
+          return [
+          \   {'name': 'rundll32',
+          \    'cmd': rundll32,
+          \    'args': rundll32 . ' url.dll,FileProtocolHandler {use_vimproc ? uri : uri_noesc}'}
+          \]
+        endif
+      endfor
     endif
     return [
     \   {'name': 'xdg-open',


### PR DESCRIPTION
Recently, `Windows` folder name was changed to uppercase on my environment (Windows 10 Pro, 10.0.15063 N/A Build 15063).

* Before: `/mnt/c/Windows/System32/rundll32.exe`
* After: `/mnt/c/WINDOWS/System32/rundll32.exe`

WSL does not ignore filename case, so it cannot find rundll32.exe.

I could not find when this filepath was changed, but for safety, searching both paths are better.