### PR TITLE
Fix type error in concatenate options in browser open on Windows

### DIFF
--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -93,9 +93,9 @@ function! s:_OpenBrowser_open(uri, ...) abort dict
       endif
     endif
 
-    if type(b.cmd.args) == 1
+    if type(b.cmd.args) == v:t_string
       "String (Windows)
-      let b.cmd.args = join([b.cmd.args] + options)
+      let b.cmd.args = join([b.cmd.args] + map(copy(options), 'shellescape(v:val)'), ' ')
     else
       "Array (Other platforms)
       let b.cmd.args += options

--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -93,7 +93,14 @@ function! s:_OpenBrowser_open(uri, ...) abort dict
       endif
     endif
 
-    let b.cmd.args += options
+    if type(b.cmd.args) == 1
+      "String (Windows)
+      let b.cmd.args = join([b.cmd.args] + options)
+    else
+      "Array (Other platforms)
+      let b.cmd.args += options
+    endif
+
     let opener = b.build()
     let failed = !opener.open()
 


### PR DESCRIPTION
Fix #141, browser open fails on Windows platform due to type error.