### PR TITLE
Add allowed_schemes to customize URI detection

### DIFF
--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -486,7 +486,7 @@ endfunction
 " * URI hostname (for no scheme URI)
 function! s:_get_url_head_pattern(schemes, pattern_set) abort
   let schemes = ['https', 'http', 'file'] + a:schemes
-  let scheme_pattern = join(sort(copy(a:schemes), 's:_by_length'), '\|')
+  let scheme_pattern = join(sort(copy(schemes), 's:_by_length'), '\|')
   let head_pattern = scheme_pattern . '\|' . a:pattern_set.host()
   return head_pattern
 endfunction

--- a/autoload/vital/__openbrowser__/OpenBrowser/Config.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser/Config.vim
@@ -194,6 +194,7 @@ function! s:default_values() abort
   \   'ttp': 'http',
   \   'ttps': 'https',
   \ },
+  \ 'allowed_schemes': [],
   \ 'fix_hosts': {},
   \ 'fix_paths': {},
   \ 'default_search': 'google',

--- a/doc/openbrowser.txt
+++ b/doc/openbrowser.txt
@@ -183,6 +183,24 @@ g:openbrowser_open_rules			*g:openbrowser_open_rules*
 	but these variable might be going to be removed for the next release)
 	Use |g:openbrowser_browser_commands| instead.
 
+g:openbrowser_allowed_schemes		*g:openbrowser_allowed_schemes*
+								(default: [])
+	If non empty, only the listed schemes and ones in
+	|g:openbrowser_fix_schemes| will be detected as URIs for opening with
+	|openbrowser-menu-smart-search|
+
+	If you execute |<Plug>(openbrowser-smart-search)| on code like: >
+		call s:SomeVimFunction()
+<	Or: >
+		function Type:SomeLuaFunction()
+<	OpenBrowser will open them as a URI.
+
+	If you set in your |ftplugin|/vim.vim and ftplugin/lua.vim: >
+		let b:openbrowser_allowed_schemes = [ 'http', 'https' ]
+<	Then only http:// and https:// links (and their short forms from
+	|g:openbrowser_fix_schemes|) will be opened as URIs for vim and lua files.
+	All others will be considered search queries.
+
 g:openbrowser_fix_schemes			*g:openbrowser_fix_schemes*
 								(default: {"ttp": "http"})
 	If this value is default,


### PR DESCRIPTION
Fix https://github.com/tyru/open-browser.vim/issues/159.

This has been bugging me for a long time, so I've finally done something about it! I don't use the commands (:OpenBrowser) much -- I have
`<Plug>(openbrowser-smart-search)` mapped to `gx` and use that a ton. I don't quite understand how this code would interact with the commands.

I've also removed the configuration TODO because it seems satisfied by this configuration option. However, I'm happy to restore the TODO if you had more in mind.

----

Problem: Some languages (vimscript, lua) use : in their syntax which is
detected by <Plug>(openbrowser-smart-search) as a URI. This results it
pointlessly opening s:URIExtractor instead of searching for
URIExtractor.

Add a configuration to skip the permissive URI detection and be very
conservative instead.

Tested with this configuration:

```vim
  " ~/.vim/ftplugin/lua.vim
  let b:openbrowser_allowed_schemes = [
    \     'http',
    \     'https',
    \ ]
```

The values are used in a pattern, so this configuration works as well:

```vim
  " ~/.vim/ftplugin/lua.vim
  let b:openbrowser_allowed_schemes = [
    \     'http(s)\?',
    \ ]
```

With that configuration, using <Plug>(openbrowser-smart-search) with the cursor on : on these Lua comments opens the link:
```lua
  -- taken from https://leafo.net/guides/setfenv-in-lua52-and-above.html
  -- taken from http://leafo.net/guides/setfenv-in-lua52-and-above.html
  -- taken from ttps://leafo.net/guides/setfenv-in-lua52-and-above.html
  -- taken from ttps://leafo.net/guides/setfenv-in-lua52-and-above.html
```
This one searches for 'leafo':
```lua
  -- taken from tt://leafo.net/guides/setfenv-in-lua52-and-above.html
```

Also fixes a bug in _get_url_head_pattern.