### PR TITLE
Remove trailing periods in extracted URLs

### DIFF
--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -475,7 +475,7 @@ function! s:_extract_urls(text, config) abort
   \ 'uri_pattern_set': pattern_set,
   \ 'head_pattern': head_pattern,
   \})
-  return map(extracted, {_, e -> trim(e.url.to_string(), '.', 2)})
+  return map(extracted, "trim(v:val.url.to_string(), '.', 2)")
 endfunction
 
 " This pattern matches:

--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -475,7 +475,7 @@ function! s:_extract_urls(text, config) abort
   \ 'uri_pattern_set': pattern_set,
   \ 'head_pattern': head_pattern,
   \})
-  return map(extracted, "trim(v:val.url.to_string(), '.', 2)")
+  return map(extracted, "substitute(v:val.url.to_string(), '\\.$', '', '')")
 endfunction
 
 " This pattern matches:

--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -405,8 +405,8 @@ function! s:_OpenBrowser_keymap_open(mode, ...) abort dict
   else
     let text = s:_get_selected_text()
     let extracted = s:_extract_urls(text, self.config)
-    for e in extracted
-      call self.open(e.url.to_string())
+    for url in extracted
+      call self.open(url)
     endfor
     return !empty(extracted)
   endif
@@ -467,15 +467,15 @@ function! s:_get_loose_pattern_set() abort
   return s:LoosePatternSet
 endfunction
 
-
 function! s:_extract_urls(text, config) abort
   let pattern_set = s:_get_loose_pattern_set()
   let schemes = keys(a:config.get('fix_schemes'))
   let head_pattern = s:_get_url_head_pattern(schemes, pattern_set)
-  return s:URIExtractor.extract_from_text(a:text, {
+  let extracted = s:URIExtractor.extract_from_text(a:text, {
   \ 'uri_pattern_set': pattern_set,
   \ 'head_pattern': head_pattern,
   \})
+  return map(extracted, {_, e -> trim(e.url.to_string(), '.', 2)})
 endfunction
 
 " This pattern matches:
@@ -575,7 +575,7 @@ endfunction
 function! s:_detect_url_cb(config) abort
   let extracted = s:_extract_urls(expand('<cWORD>'), a:config)
   if !empty(extracted)
-    return s:O.some(extracted[0].url.to_string())
+    return s:O.some(extracted[0])
   endif
   return s:O.none()
 endfunction

--- a/test/OpenBrowser.vimspec
+++ b/test/OpenBrowser.vimspec
@@ -225,4 +225,53 @@ Describe OpenBrowser-object
       Assert Equals(delivered_url, 'https://example.net/QU+UX')
     End
   End
+
+  Describe .keymap_open()
+    Before each
+      new
+    End
+
+    After each
+      close!
+    End
+
+    It opens a URL under the cursor in normal mode
+      call setline(1, 'https://example.com')
+      let opened = obj.keymap_open('n')
+      Assert True(opened)
+      sleep 100m
+      let command_executed = filereadable(tempfile)
+      Assert True(command_executed)
+      let delivered_url = get(readfile(tempfile), 0)
+      Assert Equals(delivered_url, 'https://example.com')
+    End
+
+    It opens a URL under in selected text in visual mode
+      call setline(1, 'https://example.com')
+      " Enter visual mode and select line which contains the URL and leave
+      " from visual mode immediately. This is necessary since keymap_open()
+      " extracts URLs from the last selected text.
+      execute 'normal!' "V\<Esc>"
+      let opened = obj.keymap_open('v')
+      Assert True(opened)
+      sleep 100m
+      let command_executed = filereadable(tempfile)
+      Assert True(command_executed)
+      let delivered_url = get(readfile(tempfile), 0)
+      Assert Equals(delivered_url, 'https://example.com')
+    End
+
+    It trims trailing period in URL
+      call setline(1, 'Hello, https://example.com.')
+      " Go to 'h' at https://...
+      normal! fh
+      let opened = obj.keymap_open('n')
+      Assert True(opened)
+      sleep 100m
+      let command_executed = filereadable(tempfile)
+      Assert True(command_executed)
+      let delivered_url = get(readfile(tempfile), 0)
+      Assert Equals(delivered_url, 'https://example.com')
+    End
+  End
 End


### PR DESCRIPTION
カーソル下の URL を `<Plug>(openbrowser-open)` で開く際，URL の末尾に文末のピリオドがあるとそれが URL に含まれてしまうという問題があります．例えば

```
Hello, https://example.com.
```

というテキストで 'h' の位置でキーマップを実行すると `https://example.com.` が開かれてしまいます．'.' は unreserved に含まれているので URL としては正しい動作なのですが，テキストから URL を抽出するという観点だと文末のピリオドが含まれてしまうのは都合が悪いです．さらに，URL で末尾にピリオドがつくことは現実的にはほぼ無いので，単純に末尾のピリオドを削除してしまっても問題なさそうです．

なので，この PR ではキーマップでテキスト内の URL を抽出するときのみ URL 末尾のピリオドを削除する処理を追加しました．また，`OpenBrowser.keymap_open` のテストが無さそうだったので，簡単なテストケースを足しました．