### PR TITLE
Highlight `*.vimspec` as Vim script on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vimspec linguist-language=Vim-Script


### PR DESCRIPTION
`.gitattributes` にこの設定を書いておくと[こんな感じで](https://github.com/rhysd/open-browser.vim/blob/highlight-vimspec/test/OpenBrowser.vimspec) .vimspec なファイルが Vim script としてハイライトされます．これを設定しておくと GitHub 上でコードをレビューしたりする時にハイライトが効いて読みやすいかなと #161 作成した時にちょっと思いました．もし要らなければマージせず閉じちゃってください．