### PR TITLE
Always use URI pattern matching to extract urls

### DIFF
--- a/autoload/vital/__openbrowser__/OpenBrowser.vim
+++ b/autoload/vital/__openbrowser__/OpenBrowser.vim
@@ -469,20 +469,17 @@ endfunction
 function! s:_extract_urls(text, config) abort
   let allowed_schemes = a:config.get('allowed_schemes')
   let schemes = copy(allowed_schemes) + keys(a:config.get('fix_schemes'))
+  let pattern_set = s:_get_loose_pattern_set()
   if !empty(allowed_schemes)
     let head_pattern = s:_get_url_scheme_pattern(schemes)
-    let options = {
-          \ 'head_pattern': head_pattern,
-          \}
   else
-    " When allowed_schemes is empty, match any URI.
-    let pattern_set = s:_get_loose_pattern_set()
+    " When allowed_schemes is empty, use more tolerant pattern.
     let head_pattern = s:_get_url_head_pattern(schemes, pattern_set)
-    let options = {
-          \ 'uri_pattern_set': pattern_set,
-          \ 'head_pattern': head_pattern,
-          \}
   endif
+  let options = {
+        \ 'uri_pattern_set': pattern_set,
+        \ 'head_pattern': head_pattern,
+        \}
   let extracted = s:URIExtractor.extract_from_text(a:text, options)
   return map(extracted, "substitute(v:val.url.to_string(), '\\.$', '', '')")
 endfunction


### PR DESCRIPTION
Fix #168.

Use URI pattern matching so the trailing ) is excluded in markdown links even when g:openbrowser_allowed_schemes is set. That option should modify how we select schemes (head) and not the uri pattern.

Bug introduced in b8d27c7.

# Test

These open correct links:

```
  -- taken from https://leafo.net/guides/setfenv-in-lua52-and-above.html
  -- taken from http://leafo.net/guides/setfenv-in-lua52-and-above.html
  -- taken from ttps://leafo.net/guides/setfenv-in-lua52-and-above.html
  -- taken from ttps://leafo.net/guides/setfenv-in-lua52-and-above.html
  * [tyru/open-browser-github.vim](https://github.com/tyru/open-browser-github.vim)
```

Opens `https://en.wikipedia.org/wiki/Planetoid_` which Wikipedia correctly redirects. This is the same behaviour as 91573a3 -- before my breaking change.
```markdown
* [Planetoid](https://en.wikipedia.org/wiki/Planetoid_(disambiguation))
```

Opens the link if the cursor is on `:` and searches for tyru if cursor is on `[`:
```markdown
* [tyru/open-browser-unicode.vim]( https://github.com/tyru/open-browser-unicode.vim )
```


This one searches for 'leafo':

```
  -- taken from tt://leafo.net/guides/setfenv-in-lua52-and-above.html
```

(The nonmarkdown links are from b8d27c7.)