### PR TITLE
Only test version of vim that work with ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        vim_version: [nightly, v8.0.0000, v8.2.0000]
+        # Older vim fails to configure terminal correctly.
+        vim_version: [nightly, v8.2.5135, v9.0.0000]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Building with v8.0 [fails with a warning](https://github.com/tyru/open-browser.vim/actions/runs/14579904527/job/40894110474?pr=169) explaining that this version of vim doesn't configure itself correctly:

> Warning: This version of Vim has a bug where ./configure cannot find a
> terminal library correctly. See the following issue for more details:
> https://github.com/rhysd/action-setup-vim/issues/38
>
> Error: Command './configure --prefix=/Users/runner/vim-v8.0.0000 --with-features=huge --enable-fail-if-missing' exited non-zero status 1:
> configure: error: NOT FOUND!
> You need to install a terminal library; for example ncurses.
> Or specify the name of the library with --with-tlib.

Use the version of vim that action-setup-vim identified as working. Also add v9 so we're still testing the same number of versions.